### PR TITLE
The repo publish unit tests on RHEL linux needed a "which" to resolve the path to fig-download

### DIFF
--- a/lib/fig/os.rb
+++ b/lib/fig/os.rb
@@ -104,7 +104,7 @@ module Fig
         # TODO need better way to do conditional download
         #       timestamp = `ssh #{uri.user + '@' if uri.user}#{uri.host} "ruby -e 'puts File.mtime(\\"#{uri.path}\\").to_i'"`.to_i
         timestamp = File.exist?(path) ? File.mtime(path).to_i : 0 
-        cmd = "fig-download #{timestamp} #{uri.path}"
+        cmd = `which fig-download`.strip + " #{timestamp} #{uri.path}"
         ssh_download(uri.user, uri.host, path, cmd)
       else
         raise "Unknown protocol: #{url}"


### PR DESCRIPTION
Not sure why the ssh channel exec in my env didn't use the path to find fig-download, but this seemed to help.
